### PR TITLE
Fix clipping problem for Globe in Safari

### DIFF
--- a/themes/gibbonedu/layouts/index.html
+++ b/themes/gibbonedu/layouts/index.html
@@ -162,6 +162,7 @@ aria-describedby="desc" role="img" xmlns:xlink="http://www.w3.org/1999/xlink">
                     width:400px;
                     height: 400px;
                     background-color: #aadaff;
+                    transform: translateZ(0)
                 }
 
                 #gibbonMapInner {


### PR DESCRIPTION
Safari has a bug where the overflow hidden option will not apply to corner radii.
This simple fix fixes it!